### PR TITLE
Remove polyfill.io

### DIFF
--- a/lib/Formatter/HtmlFormatter.php
+++ b/lib/Formatter/HtmlFormatter.php
@@ -120,8 +120,7 @@ class HtmlFormatter {
 
     private function getScriptsHtml()
     {
-        $html = '<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>';
-        $html .= '<script>'.file_get_contents(__DIR__ . '/../../res/bliss.min.js').'</script>';
+        $html = '<script>' . file_get_contents(__DIR__ . '/../../res/bliss.min.js') . '</script>';
         $html .= '<script>'.file_get_contents(__DIR__.'/../../res/scripts.js').'</script>';
         return $html;
     }


### PR DESCRIPTION
Removing polyfill.io cdn as it's been source of malicious behaviour, plus most modern browsers do implement the functionality polyfills are supposed to provide.